### PR TITLE
Disable log decorate

### DIFF
--- a/git-rebasetags
+++ b/git-rebasetags
@@ -50,7 +50,7 @@ while True:
 # Restore tags after rebase, matching comments
 print('Restoring tags...')
 
-OUT = run(['git', 'log', '--oneline'], stdout=PIPE).stdout.decode('utf-8').splitlines()
+OUT = run(['git', 'log', '--no-decorate', '--oneline'], stdout=PIPE).stdout.decode('utf-8').splitlines()
 
 count = 0
 for line in OUT:


### PR DESCRIPTION
  Some will configure:  git config log.decorate short
    for convenience as it provides ref/tagging information to the log output.
    Unfortunately, this extra information can cause problems for the splitting
    operations (tag comment) used later to match old ==> new tags.